### PR TITLE
Drop 'urpmq -Y' alias

### DIFF
--- a/barista-go/barista.go
+++ b/barista-go/barista.go
@@ -27,7 +27,6 @@ var cmds map[string]CommandFunc = map[string]CommandFunc{
 	"apt se":          Dnf,
 	"apt-get search":  Dnf,
 	"apt-get se":      Dnf,
-	"urpmq -Y":        Dnf,
 	"sudo profile":    Profile,
 	"sudo help":       Help,
 	"sudo ddg":        Ddg,


### PR DESCRIPTION
The behavior of urpmq(8) is so weird compared to the others that
it is not great to expose that to people.

Moreover, User RPM is basically dead, let's let it rest in pieces...